### PR TITLE
Explicitly pull data for users who haven't joined yet

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -63,6 +63,7 @@ func (c *BambooHRClient) ListUsers(ctx context.Context) (
 	users := &ReportUserResults{}
 	v := url.Values{}
 	v.Set("format", "json")
+	v.Set("onlyCurrent", "false")
 	reqURL := c.newUnPaginatedURL(UsersListUrlPath, v)
 
 	listUsersReqBody := ReqFields{


### PR DESCRIPTION
Unless `onlyCurrent` is set to `false`, BambooHR will only return a subset of fields for users whose start date has not yet arrived. By explicitly setting it, we allow ConductorOne to view all the user's details as soon as they get created.