### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-bamboohr/main.go
+++ b/cmd/baton-bamboohr/main.go
@@ -62,6 +62,7 @@ func getConnector(ctx context.Context, bhrc *cfg.Bamboohr) (types.ConnectorServe
 		ctx,
 		companyDomain,
 		apiKey,
+		bhrc.BaseUrl,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Bamboohr struct {
 	CompanyDomain string `mapstructure:"company-domain"`
 	ApiKey string `mapstructure:"api-key"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c* Bamboohr) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the BambooHR API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,10 +18,15 @@ var (
 		field.WithRequired(true),
 		field.WithIsSecret(true),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the BambooHR API URL (for testing)"),
+	)
 
 	ConfigurationFields = []field.SchemaField{
 		CompanyDomainField,
 		ApiKeyField,
+		BaseURLField,
 	}
 	Configuration = field.NewConfiguration(ConfigurationFields)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the BambooHR API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	ConfigurationFields = []field.SchemaField{

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -25,22 +25,30 @@ type Client interface {
 	ListUsers(ctx context.Context, pagination string) ([]*User, *v2.RateLimitDescription, error)
 }
 
-func New(ctx context.Context, apiKey string, companyDomain string) (*BambooHRClient, error) {
+func New(ctx context.Context, apiKey string, companyDomain string, baseURL string) (*BambooHRClient, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, nil))
 	if err != nil {
 		return nil, err
 	}
 	wrapper := uhttp.NewBaseHttpClient(httpClient)
 
-	baseUrl := url.URL{
-		Scheme: "https",
-		Host:   APIDomain,
+	var parsedBaseURL *url.URL
+	if baseURL != "" {
+		parsedBaseURL, err = url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base URL: %w", err)
+		}
+	} else {
+		parsedBaseURL = &url.URL{
+			Scheme: "https",
+			Host:   APIDomain,
+		}
 	}
 	return &BambooHRClient{
 		wrapper:       wrapper,
 		ApiKey:        apiKey,
 		CompanyDomain: companyDomain,
-		BaseUrl:       &baseUrl,
+		BaseUrl:       parsedBaseURL,
 	}, nil
 }
 

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -38,6 +38,9 @@ func New(ctx context.Context, apiKey string, companyDomain string, baseURL strin
 		if err != nil {
 			return nil, fmt.Errorf("invalid base URL: %w", err)
 		}
+		if parsedBaseURL.Scheme != "http" && parsedBaseURL.Scheme != "https" {
+			return nil, fmt.Errorf("base-url must have http or https scheme, got %q", parsedBaseURL.Scheme)
+		}
 	} else {
 		parsedBaseURL = &url.URL{
 			Scheme: "https",

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -21,8 +21,9 @@ func New(
 	ctx context.Context,
 	customerDomain string,
 	apiKey string,
+	baseURL string,
 ) (*BambooHr, error) {
-	client, err := client.New(ctx, apiKey, customerDomain)
+	client, err := client.New(ctx, apiKey, customerDomain, baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -22,6 +22,7 @@ func TestUsersList(t *testing.T) {
 			ctx,
 			"mock-access-token",
 			"mock-company",
+			"",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-bamboohr/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/client/client.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-bamboohr --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to override the BambooHR API base URL. This allows specifying a custom endpoint (useful for testing or alternative deployments); the option is available via CLI and hidden from the UI. Runtime behavior otherwise remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->