### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -64,7 +64,7 @@ Configuring the connector requires you to pass in credentials generated in Bambo
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the BambooHR connector
 
@@ -117,7 +117,7 @@ Configuring the connector requires you to pass in credentials generated in Bambo
     </Step>
 </Steps>
 
-**That's it!** Your BambooHR connector is now pulling access data into C1.
+**Done.** Your BambooHR connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the BambooHR connector, hosted and run in your own environment.**
@@ -210,7 +210,7 @@ spec:
     spec:
       containers:
       - name: baton-bamboohr
-        image: ghcr.io/conductorone/baton-bamboohr:latest
+        image: public.ecr.aws/conductorone/baton-bamboohr:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -231,7 +231,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your BambooHR connector is now pulling access data into C1.
+**Done.** Your BambooHR connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.