### PR TITLE
Remove embedded images from connector docs

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -28,9 +28,6 @@ Configuring the connector requires you to pass in credentials generated in Bambo
     </Step>
     <Step>
     Make a note of the company domain, which is found in the URL.
-    <Frame>
-    ![](/images/product/assets/bamboohr-1.png)
-    </Frame>
     </Step>
     <Step>
     Next we'll create a BambooHR API token. The user that creates the API token must be assigned an access level with these permissions:
@@ -43,21 +40,12 @@ Configuring the connector requires you to pass in credentials generated in Bambo
     </Step>
     <Step>
     Click the **BambooHR icon** in the top right corner of the page and select **API Keys**.
-    <Frame>
-    ![](/images/product/assets/bamboohr-2.png)
-    </Frame>
     </Step>
     <Step>
     On the API Keys page, select **Add New Key**.
-    <Frame>
-    ![](/images/product/assets/bamboohr-3.png)
-    </Frame>
     </Step>
     <Step>
     Enter a name for your new key and then click **Generate Key**.
-    <Frame>
-    ![](/images/product/assets/bamboohr-4.png)
-    </Frame>
     </Step>
     <Step>
     Copy the newly generated API key.


### PR DESCRIPTION
## Why

Embedded images in a connector doc make the registry's MDX-to-HTML compiler emit a `<link rel="preload">` tag that the registry's HTML validator rejects. On BambooHR v0.0.12 this wedged the Export-to-S3 docs-publish cron. Removing the embedded screenshots clears the validator failure. This also matches connector-docs convention, which is to keep embedded images out of connector docs.

## What this changes

Removes the 4 embedded screenshots (and their surrounding `<Frame>` wrappers) from `docs/connector.mdx`. The surrounding `<Step>` instructions are left intact. Only image-wrapping `<Frame>` blocks were removed.

## Related

- Matches the interim fix already applied to the registry's stored v0.0.12 doc.
- Pairs with a shared mdx-lint rule now enforcing no embedded images in connector docs (ConductorOne/github-workflows PR #101).