### PR TITLE
[DO NOT MERGE] Validate embedded-image lint (PR #101)

### DIFF
--- a/.github/workflows/connector-docs.yaml
+++ b/.github/workflows/connector-docs.yaml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   connector-docs:
-    uses: ConductorOne/github-workflows/.github/workflows/connector-docs-verify.yaml@v4
+    uses: ConductorOne/github-workflows/.github/workflows/connector-docs-verify.yaml@b918eb03bca0f95c3ab853d3220da150f3b29404
     with:
       ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -28,6 +28,9 @@ Configuring the connector requires you to pass in credentials generated in Bambo
     </Step>
     <Step>
     Make a note of the company domain, which is found in the URL.
+    <Frame>
+    ![](/images/product/assets/bamboohr-1.png)
+    </Frame>
     </Step>
     <Step>
     Next we'll create a BambooHR API token. The user that creates the API token must be assigned an access level with these permissions:
@@ -40,12 +43,21 @@ Configuring the connector requires you to pass in credentials generated in Bambo
     </Step>
     <Step>
     Click the **BambooHR icon** in the top right corner of the page and select **API Keys**.
+    <Frame>
+    ![](/images/product/assets/bamboohr-2.png)
+    </Frame>
     </Step>
     <Step>
     On the API Keys page, select **Add New Key**.
+    <Frame>
+    ![](/images/product/assets/bamboohr-3.png)
+    </Frame>
     </Step>
     <Step>
     Enter a name for your new key and then click **Generate Key**.
+    <Frame>
+    ![](/images/product/assets/bamboohr-4.png)
+    </Frame>
     </Step>
     <Step>
     Copy the newly generated API key.


### PR DESCRIPTION
**DO NOT MERGE.** This is a throwaway CI-validation branch, kept only as evidence.

## Why

We added a new mdx-lint rule (unmerged, ConductorOne/github-workflows PR #101, commit b918eb0) that rejects connector docs containing embedded images. baton-bamboohr main was just cleaned by #28, which removed all embedded images, so main now passes. To prove the new rule actually fails CI on a doc with images, we need a branch that has the bad images AND runs the new lint.

## What this changes

- Re-adds the 4 embedded-image blocks to `docs/connector.mdx` that #28 removed (recreates the pre-#28 bad doc).
- Pins `.github/workflows/connector-docs.yaml` to the unmerged lint SHA `b918eb03bca0f95c3ab853d3220da150f3b29404` instead of `@v4`.

Expected result: the **Connector Docs** check fails with the new rule error ("contains an embedded image; connector docs must not embed images"). A failing check here is a PASS for this validation.

This branch must never be merged.