### PR TITLE
Fix CI: derive Go version from go.mod instead of hardcoding

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,12 +4,12 @@ jobs:
   go-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
-      - name: Checkout code
-        uses: actions/checkout@v4
+          go-version-file: "go.mod"
       - name: Run linters
         uses: golangci/golangci-lint-action@v8
         with:
@@ -18,17 +18,16 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [1.22.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         if: success()
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v4
+          go-version-file: "go.mod"
       - name: go tests
         run: go test -v -covermode=count -json ./... > test.json
       - name: annotate go tests

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,12 +7,12 @@ jobs:
   go-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
-      - name: Checkout code
-        uses: actions/checkout@v4
+          go-version-file: "go.mod"
       - name: Run linters
         uses: golangci/golangci-lint-action@v8
         with:
@@ -21,17 +21,16 @@ jobs:
   go-test:
     strategy:
       matrix:
-        go-version: [ 1.22.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         if: success()
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v4
+          go-version-file: "go.mod"
       - name: go tests
         run: go test -v -covermode=count -json ./... > test.json
       - name: annotate go tests


### PR DESCRIPTION
## Summary
- `ci.yaml` and `main.yaml` were still pinned to `go-version: 1.22.x`, out of sync with the `go.mod` `go` directive (bumped to `1.25.2` by a recent dependency update).
- Switched both workflows to `go-version-file: "go.mod"`, matching the pattern already used in `capabilities_and_config.yaml`, so CI always tracks whatever Go version `go.mod` specifies.
- Reordered steps so checkout happens before `setup-go`, since it now needs to read `go.mod` from the checked-out repo.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] CI runs green on this PR